### PR TITLE
fixing go get package path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An implementation of [Cucumber][cuke] BDD-style testing for Go.
 # Installing
 
 ```sh
-$ go get github.com/lsegal/cmd/gucumber
+$ go get github.com/lsegal/gucumber/cmd/gucumber
 ```
 
 # Usage


### PR DESCRIPTION
Small patch to fix the package path documented on the `go get` command