### PR TITLE
Path to repo for installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An implementation of [Cucumber][cuke] BDD-style testing for Go.
 # Installing
 
 ```sh
-$ go get github.com/lsegal/cmd/gucumber
+$ go get github.com/lsegal/gucumber
 ```
 
 # Usage


### PR DESCRIPTION
README.md install instructions don't work.

`go get github.com/lsegal/cmd/gucumber` 

I updated it to: 

`go get github.com/lsegal/gucumber` 