### PR TITLE
Propagation of os.Args to child process

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -72,9 +72,14 @@ func BuildAndRunDir(dir string, filters []string) error {
 	tplMain.Execute(f, info)
 	f.Close()
 
-	// now run the command
+	// prepare arguments
+	osArgs := os.Args[1:]
 	tfile := "./" + filepath.ToSlash(dir) + "/_test/" + testFile
-	cmd := exec.Command("go", "run", tfile)
+	args := []string{"run", tfile}
+	args = append(args, osArgs...)
+
+	// now run the command
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
ISSUE:

I wanted my step_definitions.php code to have access to command-line arguments via the "flag" module. I created mygucumber.go (a clone of gucumber.go) and added a custom flag:

./mygucumber --outfile=/tmp/foo.txt

I then attempted to use the "flag" module from step_definitions.go but found that os.Args was empty. The reason is because builder.go creates a sub-command for the step definitions and runs it using exec.Command to create a sub-process. The command it constructs does not carry over any of the arguments passed in from the top level.

SOLUTION:

Modified builder.go to include the command line arguments in it's sub-process command.