### PR TITLE
Amend the template builder to extract the correct import path

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,19 @@
+package gucumber
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackageImportPathIsExtractedFromFilePath(t *testing.T) {
+	//arrange
+	packageName := "github.com/username/reponame"
+	file := filepath.Join(os.Getenv("GOPATH"), "src/github.com/username/reponame/main.go")
+	//act
+	importPath := assembleImportPath(file)
+	//assert
+	assert.Equal(t, packageName, importPath)
+}


### PR DESCRIPTION
When determining the import path, the template builder was cutting off the first letter for me on Windows, so instead of:
*github.com/username/reopname*
it would return
*ithub.com/username/reponame*

The pull request extracts determining the import path into a private function that acts on a full file path, using the filepath package to extract the import path and ensure the path separators are correct.

A test file, builder_test.go, has also been created.