### PR TITLE
Add support for passing in Go Build Tags to generated feature go files.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -15,7 +15,22 @@ const (
 	testFile         = "gucumbertest__.go"
 )
 
+// BuildAndRunDir builds the given director's features into Go Code.
+// Using the filters provided. An error is returned if the build fails.
 func BuildAndRunDir(dir string, filters []string) error {
+	return buildAndRunDir(dir, filters, "")
+}
+
+// BuildAndRunDirWithGoBuildTags builds the given director's features into Go
+// Code using the filters provided. Also takes a string for the build tags to
+// be passed to the go command. An error is returned if the build fails.
+//
+// If goBuildTags is empty, the param will be ignored.
+func BuildAndRunDirWithGoBuildTags(dir string, filters []string, goBuildTags string) error {
+	return buildAndRunDir(dir, filters, goBuildTags)
+}
+
+func buildAndRunDir(dir string, filters []string, goBuildTags string) error {
 	defer buildCleanup(dir)
 
 	info := buildInfo{
@@ -63,7 +78,12 @@ func BuildAndRunDir(dir string, filters []string) error {
 
 	// now run the command
 	tfile := "./" + filepath.ToSlash(dir) + "/_test/" + testFile
-	cmd := exec.Command("go", "run", tfile)
+	var cmd *exec.Cmd
+	if len(goBuildTags) > 0 {
+		cmd = exec.Command("go", "run", "-tags", goBuildTags, tfile)
+	} else {
+		cmd = exec.Command("go", "run", tfile)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/run_main.go
+++ b/run_main.go
@@ -17,9 +17,11 @@ func (f *filters) Set(value string) error {
 }
 
 var filterFlag filters
+var goBuildTags string
 
 func init() {
 	flag.Var(&filterFlag, "tags", "comma-separated list of tags to filter scenarios by")
+	flag.StringVar(&goBuildTags, "go-tags", "", "space seperated list of tags, wrap in quotes to specify multiple tags")
 }
 
 func RunMain() {
@@ -36,7 +38,7 @@ func RunMain() {
 	for _, f := range filterFlag {
 		filt = append(filt, string(f))
 	}
-	if err := BuildAndRunDir(dir, filt); err != nil {
+	if err := BuildAndRunDirWithGoBuildTags(dir, filt, goBuildTags); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
We found it would be helpful to separate our integration feature code and its dependencies from the main code base. In the general case users of the library wouldn't need to pull down the testing dependencies when using the `go get -u github.com/aws/aws-sdk-go/...` pattern. To do this we'd like to add go build tags to the testing packages. This PR adds the ability to pass in these build tags to the generated code feature runners.

Related to aws/aws-sdk-go#737, aws/aws-sdk-go#449